### PR TITLE
open video in youtube app if available

### DIFF
--- a/YouTubePlayer/YouTubePlayer/YouTubePlayer.swift
+++ b/YouTubePlayer/YouTubePlayer/YouTubePlayer.swift
@@ -347,7 +347,20 @@ open class YouTubePlayerView: UIView, UIWebViewDelegate {
         
         // Check if ytplayer event and, if so, pass to handleJSEvent
         if let url = url, url.scheme == "ytplayer" { handleJSEvent(url) }
-        
+       
+        // Open the video in youtube app
+        if let url = url {
+            if url.absoluteString.contains("watch?v=") {
+                guard let appUrl = URL(string: url.absoluteString.replacingOccurrences(of: "https", with: "youtube")) else { return false }
+                //Check if the youtube app is available or open the link in Safari
+                if UIApplication.shared.canOpenURL(appUrl) {
+                    UIApplication.shared.openURL(appUrl) // Youtube app
+                } else if UIApplication.shared.canOpenURL(url) {
+                    UIApplication.shared.openURL(url) // Safari
+                }
+                return false
+            }
+        }
         return true
     }
 }


### PR DESCRIPTION
If the user click on the title or YouTube logo it will be directed to the YouTube app if it is installed in the device or on Safari if the app is not available

The current behavior is directing the user to the YouTube page inside the Webview and the user can browse to different videos and so on !!.